### PR TITLE
feat: misc improvements

### DIFF
--- a/app/components/AddToCart/AddToCart.tsx
+++ b/app/components/AddToCart/AddToCart.tsx
@@ -1,21 +1,30 @@
+import type {
+  Attribute,
+  SellingPlan,
+} from '@shopify/hydrogen/storefront-api-types';
+
 import {BackInStockModal, LoadingDots} from '~/components';
 import {useAddToCart} from '~/hooks';
 import type {SelectedVariant} from '~/lib/types';
 
 interface AddToCartProps {
   addToCartText?: string;
+  attributes?: Attribute[];
   className?: string;
   isPdp?: boolean;
   quantity?: number;
   selectedVariant: SelectedVariant;
+  sellingPlanId?: SellingPlan['id'];
 }
 
 export function AddToCart({
   addToCartText = '',
+  attributes,
   className = '',
   isPdp = false,
   quantity = 1,
   selectedVariant,
+  sellingPlanId,
 }: AddToCartProps) {
   const {
     buttonText,
@@ -29,8 +38,10 @@ export function AddToCart({
     handleNotifyMe,
   } = useAddToCart({
     addToCartText,
+    attributes,
     quantity,
     selectedVariant,
+    sellingPlanId,
   });
 
   const isUpdatingClass = isAdding || cartIsUpdating ? 'cursor-default' : '';

--- a/app/components/Document/BodyScripts.tsx
+++ b/app/components/Document/BodyScripts.tsx
@@ -1,10 +1,9 @@
 import {Script} from '@shopify/hydrogen';
 
-import {useIsHydrated, useRootLoaderData} from '~/hooks';
+import {useRootLoaderData} from '~/hooks';
 
-export function Scripts() {
+export function BodyScripts() {
   const {ENV} = useRootLoaderData();
-  const isHydrated = useIsHydrated();
 
   return (
     <>
@@ -15,7 +14,7 @@ export function Scripts() {
         }}
       />
 
-      {isHydrated && ENV?.PUBLIC_GTM_CONTAINER_ID && (
+      {ENV?.PUBLIC_GTM_CONTAINER_ID && (
         <Script
           id="gtm-script"
           type="text/javascript"
@@ -34,4 +33,4 @@ export function Scripts() {
   );
 }
 
-Scripts.displayName = 'Scripts';
+BodyScripts.displayName = 'BodyScripts';

--- a/app/components/Document/Document.tsx
+++ b/app/components/Document/Document.tsx
@@ -16,7 +16,8 @@ import {Analytics, DataLayer, Layout} from '~/components';
 import {useLocale, useRootLoaderData} from '~/hooks';
 
 import {Favicon} from './Favicon';
-import {Scripts as RootScripts} from './Scripts';
+import {BodyScripts} from './BodyScripts';
+import {HeadScripts} from './HeadScripts';
 
 interface DocumentProps {
   children: ReactNode;
@@ -57,6 +58,7 @@ export function Document({children, title}: DocumentProps) {
                 />
                 <meta name="keywords" content={keywords} />
                 <Favicon />
+                <HeadScripts />
                 <Seo />
                 <Meta />
                 <Links />
@@ -74,7 +76,7 @@ export function Document({children, title}: DocumentProps) {
                 </PreviewProvider>
                 <Analytics />
                 <DataLayer />
-                <RootScripts />
+                <BodyScripts />
                 <ScrollRestoration
                   getKey={(location) => {
                     const isPdp = location.pathname.startsWith('/products/');

--- a/app/components/Document/HeadScripts.tsx
+++ b/app/components/Document/HeadScripts.tsx
@@ -1,0 +1,13 @@
+import {Script} from '@shopify/hydrogen';
+
+export function HeadScripts() {
+  return (
+    <>
+      {/* Third-party scripts *required* in the head.
+       * Place scripts in the body where possible to improve performance.
+       */}
+    </>
+  );
+}
+
+HeadScripts.displayName = 'HeadScripts';

--- a/app/components/QuantitySelector/QuantitySelector.tsx
+++ b/app/components/QuantitySelector/QuantitySelector.tsx
@@ -1,6 +1,7 @@
 import {Spinner, Svg} from '~/components';
 
 interface QuantitySelectorProps {
+  disabled?: boolean;
   disableDecrement?: boolean;
   handleDecrement: () => void;
   handleIncrement: () => void;
@@ -10,6 +11,7 @@ interface QuantitySelectorProps {
 }
 
 export function QuantitySelector({
+  disabled = false,
   disableDecrement = false,
   handleDecrement,
   handleIncrement,
@@ -26,7 +28,7 @@ export function QuantitySelector({
         className={`relative h-8 w-8 rounded-full border border-border transition disabled:opacity-50 ${
           disableDecrement ? 'cursor-not-allowed' : 'md:hover:border-gray'
         }`}
-        disabled={isUpdating || disableDecrement}
+        disabled={disabled || isUpdating || disableDecrement}
         onClick={handleDecrement}
         type="button"
       >
@@ -51,7 +53,7 @@ export function QuantitySelector({
           quantity + 1
         }`}
         className="relative h-8 w-8 rounded-full border border-border transition disabled:opacity-50 md:hover:border-gray"
-        disabled={isUpdating}
+        disabled={disabled || isUpdating}
         onClick={handleIncrement}
         type="button"
       >

--- a/app/hooks/product/useAddToCart.ts
+++ b/app/hooks/product/useAddToCart.ts
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useState} from 'react';
 import {useCart} from '@shopify/hydrogen-react';
 import {useSiteSettings} from '@pack/react';
 import type {
-  AttributeInput,
+  Attribute,
   ProductVariant,
   SellingPlan,
 } from '@shopify/hydrogen/storefront-api-types';
@@ -31,7 +31,7 @@ import {useGlobal} from '~/hooks';
 
 interface UseAddToCartProps {
   addToCartText?: string;
-  attributes?: AttributeInput[];
+  attributes?: Attribute[];
   quantity?: number;
   selectedVariant?: ProductVariant | null;
   sellingPlanId?: SellingPlan['id'];

--- a/app/routes/($locale).api.predictive-search.tsx
+++ b/app/routes/($locale).api.predictive-search.tsx
@@ -54,7 +54,7 @@ async function fetchPredictiveSearchResults({
     body = await request.formData();
   } catch (error) {}
   const searchTerm = String(body?.get('q') || searchParams.get('q') || '');
-  const limit = Number(body?.get('limit') || searchParams.get('limit') || 10);
+  const limit = Number(body?.get('limit') || searchParams.get('limit')) || 10;
   const rawTypes = String(
     body?.get('type') || searchParams.get('type') || 'ANY',
   );

--- a/app/routes/($locale).api.products.tsx
+++ b/app/routes/($locale).api.products.tsx
@@ -62,7 +62,7 @@ export async function action({request, context}: ActionFunctionArgs) {
   const reverse = Boolean(
     body?.get('reverse') || searchParams.get('reverse') || false,
   );
-  const count = Number(body?.get('count') || searchParams.get('count') || 10);
+  const count = Number(body?.get('count') || searchParams.get('count')) || 10;
 
   const {products} = await queryProducts({
     context,

--- a/app/routes/($locale).collections.$handle.tsx
+++ b/app/routes/($locale).collections.$handle.tsx
@@ -43,8 +43,8 @@ export async function loader({params, context, request}: LoaderFunctionArgs) {
   const resultsPerPage = Math.floor(
     Number(
       siteSettings?.data?.siteSettings?.settings?.collection?.pagination
-        ?.resultsPerPage || '24',
-    ),
+        ?.resultsPerPage,
+    ) || 24,
   );
 
   const paginationVariables = getPaginationVariables(request, {

--- a/app/routes/($locale).search.tsx
+++ b/app/routes/($locale).search.tsx
@@ -39,7 +39,7 @@ export async function action({request, context}: ActionFunctionArgs) {
       searchTypes: ['PRODUCT'],
     });
 
-  const count = Number(body?.get('count') || searchParams.get('count') || 10);
+  const count = Number(body?.get('count') || searchParams.get('count')) || 10;
 
   const {search} = await storefront.query(PRODUCTS_SEARCH_QUERY, {
     variables: {

--- a/app/sections/HalfHero/HalfHeroMedia.tsx
+++ b/app/sections/HalfHero/HalfHeroMedia.tsx
@@ -36,7 +36,7 @@ export function HalfHeroMedia({
             }}
             aspectRatio={getAspectRatioFromPercentage(aspectMobile)}
             crop={image?.cropMobile}
-            className={`media-fill`}
+            className="media-fill"
             loading={aboveTheFold ? 'eager' : 'lazy'}
             sizes="100vw"
           />
@@ -64,7 +64,7 @@ export function HalfHeroMedia({
             }}
             aspectRatio={getAspectRatioFromPercentage(aspectDesktop)}
             crop={image?.cropDesktop}
-            className={`media-fill`}
+            className="media-fill"
             loading={aboveTheFold ? 'eager' : 'lazy'}
             sizes="50vw"
           />


### PR DESCRIPTION
- Adds `attributes` and `sellingPlanId` props to `AddToCart`
- Breaks out body scripts and head scripts into two separate files
- Removes `isHydrated` conditional around the placeholder GTM script
- Adds `disabled` prop to `QuantitySelector` in order to disable both buttons while still being displayed
- Moves `Number()` fallback outside constructor to prevent specific edge cases with `Number()` not accepting a fallback
- Misc syntax cleanup